### PR TITLE
Add "difficulty" column to block list

### DIFF
--- a/src/MicroCore.cpp
+++ b/src/MicroCore.cpp
@@ -143,6 +143,45 @@ MicroCore::get_block_by_height(const uint64_t& height, block& blk)
 
 
 
+/** Get the difficulty at the given height */
+bool
+MicroCore::get_diff_at_height(const uint64_t& height, uint64_t& diff)
+{
+    try
+    {
+        diff = m_blockchain_storage.get_db().get_block_difficulty(height);
+    }
+    catch (const BLOCK_DNE& e)
+    {
+        cerr << "Block of height " << height
+             << " not found in the blockchain!"
+             << e.what()
+             << endl;
+
+        return false;
+    }
+    catch (const DB_ERROR& e)
+    {
+        cerr << "Blockchain access error when getting block " << height
+             << e.what()
+             << endl;
+
+        return false;
+    }
+    catch (...)
+    {
+        cerr << "Something went terribly wrong when getting block " << height
+             << endl;
+
+        return false;
+    }
+
+    return true;
+}
+
+
+
+
 /**
  * Get transaction tx from the blockchain using it hash
  */

--- a/src/MicroCore.h
+++ b/src/MicroCore.h
@@ -44,6 +44,9 @@ namespace xmreg
         get_block_by_height(const uint64_t& height, block& blk);
 
         bool
+        get_diff_at_height(const uint64_t& height, uint64_t& blk);
+
+        bool
         get_tx(const crypto::hash& tx_hash, transaction& tx);
 
         bool

--- a/src/page.h
+++ b/src/page.h
@@ -619,6 +619,13 @@ namespace xmreg
                         continue;
                     }
 
+                    uint64_t blk_diff;
+                    if (!mcore->get_diff_at_height(i, blk_diff))
+                    {
+                        cerr << "Cant get block diff: " << i << endl;
+                        return fmt::format("Cant get block diff {:d}!", i);
+                    }
+
                     uint64_t tx_i {0};
 
                     // this vector will go into block_tx cache
@@ -637,6 +644,7 @@ namespace xmreg
                         txd_map.insert({"height"    , i});
                         txd_map.insert({"blk_hash"  , blk_hash_str});
                         txd_map.insert({"age"       , age.first});
+                        txd_map.insert({"diff"      , blk_diff});
                         txd_map.insert({"is_ringct" , (tx.version > 1)});
                         txd_map.insert({"rct_type"  , tx.rct_signatures.type});
                         txd_map.insert({"blk_size"  , blk_size_str});
@@ -647,6 +655,7 @@ namespace xmreg
                         {
                             txd_map["height"]     = string("");
                             txd_map["age"]        = string("");
+                            txd_map["diff"]       = string("");
                             txd_map["blk_size"]   = string("");
                         }
 
@@ -1007,6 +1016,12 @@ namespace xmreg
                 cerr << "Cant get block: " << _blk_height << endl;
                 return fmt::format("Cant get block {:d}!", _blk_height);
             }
+            uint64_t blk_diff;
+            if (!mcore->get_diff_at_height(_blk_height, blk_diff))
+            {
+                cerr << "Cant get block diff: " << _blk_height << endl;
+                return fmt::format("Cant get block diff {:d}!", _blk_height);
+            }
 
             // get block's hash
             crypto::hash blk_hash = core_storage->get_block_id_by_height(_blk_height);
@@ -1070,6 +1085,7 @@ namespace xmreg
                     {"testnet"              , testnet},
                     {"blk_hash"             , blk_hash_str},
                     {"blk_height"           , _blk_height},
+                    {"diff"             , blk_diff},
                     {"blk_timestamp"        , blk_timestamp},
                     {"blk_timestamp_epoch"  , blk.timestamp},
                     {"prev_hash"            , prev_hash_str},
@@ -4288,6 +4304,12 @@ namespace xmreg
                     j_response["message"] = fmt::format("Cant get block: {:d}", i);
                     return j_response;
                 }
+                uint64_t blk_diff;
+                if (!mcore->get_diff_at_height(i, blk_diff))
+                {
+                    cerr << "Cant get block diff: " << i << endl;
+                    return fmt::format("Cant get block diff {:d}!", i);
+                }
 
                 // get block size in bytes
                 double blk_size = core_storage->get_db().get_block_size(i);
@@ -4301,6 +4323,7 @@ namespace xmreg
                         {"height"       , i},
                         {"hash"         , pod_to_hex(blk_hash)},
                         {"age"          , age.first},
+                        {"diff"         , blk_diff},
                         {"size"         , blk_size},
                         {"timestamp"    , blk.timestamp},
                         {"timestamp_utc", xmreg::timestamp_to_str_gm(blk.timestamp)},

--- a/src/templates/index2.html
+++ b/src/templates/index2.html
@@ -72,6 +72,7 @@
                 <tr>
                     <td>height</td>
                     <td>age {{age_format}}<!--(Δm)--></td>
+                    <td>difficulty</td>
                     <td>size [kB]<!--(Δm)--></td>
                     <td>tx hash</td>
                     <td>fees</td>
@@ -84,6 +85,7 @@
                 <tr>
                     <td><a href="/block/{{height}}">{{height}}</a></td>
                     <td>{{age}}<!--{{time_delta}}--></td>
+                    <td>{{diff}}</td>
                     <td>{{blk_size}}</td>
                     <td><a href="/tx/{{hash}}">{{hash}}</a></td>
                     <td>{{tx_fee_short}}</td>


### PR DESCRIPTION
This adds a difficulty column to the main page of the block explorer which is really convenient for seeing how difficulty is moving over blocks.

It's live at https://blocks.imaginary.stream