### PR TITLE
Prefix negative ages with a "-"

### DIFF
--- a/src/page.h
+++ b/src/page.h
@@ -5899,6 +5899,14 @@ namespace xmreg
                 age_format = string("[d:h:m:s]");
             }
 
+            // Prefix with - if this is a negative difference (e.g. due to a forged future
+            // timestamp)
+            if (timestamp1 < timestamp2)
+            {
+                age_str = "-" + age_str;
+                age_format = "-" + age_format;
+            }
+
             age_pair.first  = age_str;
             age_pair.second = age_format;
 


### PR DESCRIPTION
The current code always shows the absolute value when calculating an
age; this change makes it prefix future timestamps (e.g. from timestamp
forging) in the blockchain list with a -.